### PR TITLE
fix: Truffle blink link to go to prod site

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ a URL.
 ## NFTs and Collectibles
 
 - [Tensor.trade](https://www.tensor.trade/trade/tensorians) - Trade NFTs on Tensor.
-- [truffle.tech](https://dial.to/?action=solana-action:https://truffle.tech/solana-actions/mint/test-solana-actions) - Mint NFTs from collections.
+- [truffle.wtf](https://truffle.wtf/project/test-solana-actions) - Mint NFTs from collections.
 - [3.land](https://3.land/item/FqpWuEUcvAmnpSfo5EmigPYd8XYGyWbwzty8zrqmy6Qj) - Minting via blinks.
 - [dReader Comics](https://dreader.app/mint/48) - Mint comics from the dReader platform.
 


### PR DESCRIPTION
Thanks for including us in your list of awesome blinks! 

This PR is to update where the Truffle example link goes. Currently it's using our test environment and not our production one.

I am one of the team members on Truffle but if you'd like to verify further feel free to either reach out to me on twitter @urbentom or contact the Truffle team directly via discord or twitter which can be found of the Truffle site. 

Thanks! 
